### PR TITLE
Fixing wall curving down at an angle

### DIFF
--- a/2d-raycaster-project/2d-raycaster-project/Classes/Raycaster.cs
+++ b/2d-raycaster-project/2d-raycaster-project/Classes/Raycaster.cs
@@ -181,29 +181,43 @@ namespace _2d_raycaster_project
                         break;
                 }
 
-                // Calculate texture coordinates based on wall hit
-                double wallHitX;
-                if (side == 0) // Ray hits a vertical wall
-                {
-                    wallHitX = player.Y + perpWallDist * rayDirY;
-                }
-                else // Ray hits a horizontal wall
-                {
-                    wallHitX = player.X + perpWallDist * rayDirX;
-                }
-                wallHitX -= Math.Floor(wallHitX); // Normalize wallHitX to a fraction between 0 and 1
                 if (texture != null)
                 {
                     // Calculate texture coordinates based on wall hit
+                    double wallHitX;
+                    if (side == 0) // Ray hits a vertical wall
+                    {
+                        wallHitX = player.Y + perpWallDist * rayDirY;
+                    }
+                    else // Ray hits a horizontal wall
+                    {
+                        wallHitX = player.X + perpWallDist * rayDirX;
+                    }
+                    wallHitX -= Math.Floor(wallHitX); // Normalize wallHitX to a fraction between 0 and 1
+
+                    // Calculate texture coordinates based on wall hit
                     int texX = (int)(texture.Width * wallHitX);
+                    if (texX < 0) texX = 0;
+                    if (texX >= texture.Width) texX = texture.Width - 1;
 
-                    // Define source and destination rectangles for drawing the textured wall
-                    Rectangle srcRect = new Rectangle(texX, 0, 1, texture.Height); // Source rectangle from texture
-                    Rectangle destRect = new Rectangle(i, drawStart, 1, lineHeight); // Destination rectangle on screen
+                    // Loop through each vertical pixel of the wall slice
+                    for (int y = drawStart; y < drawEnd; y++)
+                    {
+                        int d = y * 256 - screenHeight * 128 + lineHeight * 128; // 256 and 128 factors to avoid floats
+                        int texY = ((d * texture.Height) / lineHeight) / 256;
 
-                    // Draw the textured vertical line
-                    _graphics.DrawImage(texture, destRect, srcRect, GraphicsUnit.Pixel);
+                        // Ensure texY is within the bounds of the texture height
+                        if (texY < 0) texY = 0;
+                        if (texY >= texture.Height) texY = texture.Height - 1;
+
+                        // Set the color from the texture pixel
+                        color = texture.GetPixel(texX, texY);
+
+                        // Draw the pixel
+                        _bitmap.SetPixel(i, y, color);
+                    }
                 }
+
             }
 
             // calculate FPS

--- a/2d-raycaster-project/2d-raycaster-project/Classes/Raycaster.cs
+++ b/2d-raycaster-project/2d-raycaster-project/Classes/Raycaster.cs
@@ -22,8 +22,8 @@ namespace _2d_raycaster_project
         private Stopwatch stopwatch = new Stopwatch();
         private int frameCount = 0;
         private double fps = 0.0;
-        private const int fpsUpdateInterval = 16; // Update FPS value every 16 frames
-        private const float BufferDistance = 0.1f; // Adjust this value as needed
+        private const int FPS_UPDATE_INTERVAL = 16; // Update FPS value every 16 frames
+        private const float BUFFER_DISTANCE = 0.1f; // Adjust this for the player boundary to the walls
 
         private const int MAP_WIDTH = 10;
         private const int MAP_HEIGHT = 10;
@@ -208,7 +208,7 @@ namespace _2d_raycaster_project
 
             // calculate FPS
             frameCount++;
-            if (frameCount >= fpsUpdateInterval)
+            if (frameCount >= FPS_UPDATE_INTERVAL)
             {
                 stopwatch.Stop();
                 fps = frameCount / (stopwatch.ElapsedMilliseconds / 1000.0);
@@ -243,7 +243,7 @@ namespace _2d_raycaster_project
                             float deltaX = x - nearestX;
                             float deltaY = y - nearestY;
 
-                            if ((deltaX * deltaX + deltaY * deltaY) < (BufferDistance * BufferDistance))
+                            if ((deltaX * deltaX + deltaY * deltaY) < (BUFFER_DISTANCE * BUFFER_DISTANCE))
                             {
                                 return true;
                             }

--- a/2d-raycaster-project/2d-raycaster-project/Form1.Designer.cs
+++ b/2d-raycaster-project/2d-raycaster-project/Form1.Designer.cs
@@ -40,7 +40,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(682, 453);
+            this.ClientSize = new System.Drawing.Size(700, 500);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
             this.Name = "Form1";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;

--- a/2d-raycaster-project/2d-raycaster-project/Form1.Designer.cs
+++ b/2d-raycaster-project/2d-raycaster-project/Form1.Designer.cs
@@ -40,7 +40,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(682, 453);
+            this.ClientSize = new System.Drawing.Size(482, 253);
             this.Name = "Form1";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "2DRaycaster";

--- a/2d-raycaster-project/2d-raycaster-project/Form1.Designer.cs
+++ b/2d-raycaster-project/2d-raycaster-project/Form1.Designer.cs
@@ -40,8 +40,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(700, 500);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
+            this.ClientSize = new System.Drawing.Size(682, 453);
             this.Name = "Form1";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "2DRaycaster";

--- a/2d-raycaster-project/2d-raycaster-project/Form1.cs
+++ b/2d-raycaster-project/2d-raycaster-project/Form1.cs
@@ -22,6 +22,7 @@ namespace _2d_raycaster_project
         public Form1()
         {
             InitializeComponent();
+            this.DoubleBuffered = true;
 
             offScreenBitmap = new Bitmap(this.Width, this.Height);
             offScreenGraphics = Graphics.FromImage(offScreenBitmap);


### PR DESCRIPTION
This pull request is to fix a problem with the walls curving down when the player is viewing them from an angle, and also when the player gets too close parallel to the walls.

Here's is an image of the problem.
![image](https://github.com/Archimeeties/2DRaycaster/assets/94159379/b02def7f-6e9b-428f-b220-451637bba898)

I suspect that the reason this is happening is because it is trying to fit the whole texture into the screen when the border of the screen intersects with the wall, as demonstrated by the curving of the top of the texture.

Edit (01/06/24): It could be a problem with how I'm rendering the textures, as they only have a height and not a width, so when it is rendering a wall, it only takes into account the height of the texture, and not the width, so it just displays the whole height of the texture.

Edit (02/06/24): I have decided that it would be impractical to fix this bug, as every solution I have tried to implement drops the performance drastically. So, I'm just going to have to live with it, until I figure out a way to fix it without hindering performance. Which I'll leave for a later date.

Edit (02/06/24): Apparently, the bug is now fixed. It was caused by how I was calculating the drawStart position of the textures, and whilst experimenting with a jumping feature, I altered part of that code, and it started working, no hinder to performance at all. One tiny mistake caused me so much trouble bruh.
The changed code that made it work:
![image](https://github.com/Archimeeties/2DRaycaster/assets/94159379/d376fbef-68a4-4844-9136-1902342d667c)
How it looks now:
![image](https://github.com/Archimeeties/2DRaycaster/assets/94159379/aa266219-45a8-44c1-9f9d-da2f23f6fcfe)

